### PR TITLE
added server_sep option to the gruntfile, to allow uploads from windows systems to unix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ To use this task you will need to include the following configuration in your _g
     },
     src: '/path/to/source/folder',
     dest: '/path/to/destination/folder',
-    exclusions: ['/path/to/source/folder/**/.DS_Store', '/path/to/source/folder/**/Thumbs.db', 'dist/tmp']
+    exclusions: ['/path/to/source/folder/**/.DS_Store', '/path/to/source/folder/**/Thumbs.db', 'dist/tmp'],
+    server_sep: '/'
   }
 }
 ```
@@ -43,7 +44,8 @@ The parameters in our configuration are:
 - **authKey** - a key for looking up the saved credentials
 - **src** - the source location, the local folder that we are transferring to the server
 - **dest** - the destination location, the folder on the server we are deploying to
-- **exclusions** - an optional parameter allowing us to exclude files and folders by utilizing grunt's support for `minimatch`. Please note that the definitions should be relative to the project root.
+- **exclusions** - an optional parameter allowing us to exclude files and folders by utilizing grunt's support for `minimatch`. Please note that the definitions should be relative to the project root
+- **server_sep** - an optional parameter allowing you to define the server separator in case it differs from your local environment. Useful if you deploy from Windows to Unix
 
 ## Authentication parameters
 

--- a/tasks/sftp-deploy.js
+++ b/tasks/sftp-deploy.js
@@ -25,7 +25,9 @@ module.exports = function(grunt) {
   var sshConn;
   var localRoot;
   var remoteRoot;
+  var remoteSep;
   var currPath;
+  var remotePath;
   var authVals;
   var exclusions;
 
@@ -80,12 +82,18 @@ module.exports = function(grunt) {
       return true;
     }
 
+    if(currPath.indexOf(path.sep) !== -1){
+      remotePath = currPath.replace(path.sep, remoteSep);
+    }else{
+      remotePath = currPath;
+    }
+
     if (currPath !== path.sep) {
       fromFile = localRoot + path.sep + currPath + path.sep + inFilename;
-      toFile = remoteRoot + path.sep + currPath + path.sep + inFilename;
+      toFile = remoteRoot + remoteSep + remotePath + remoteSep + inFilename;
     } else {
       fromFile = localRoot + path.sep + inFilename;
-      toFile = remoteRoot + path.sep + inFilename;
+      toFile = remoteRoot + remoteSep + inFilename;
     }
     // console.log(fromFile + ' to ' + toFile);
     process.stdout.write(fromFile + ' to ' + toFile);
@@ -126,7 +134,14 @@ module.exports = function(grunt) {
 
     currPath = inPath;
     files = toTransfer[inPath];
-    remotePath = remoteRoot + (inPath == path.sep ? inPath : path.sep + inPath);
+
+    if(inPath.indexOf(path.sep) !== -1){
+      remoteInPath = inPath.replace(path.sep, remoteSep);
+    }else{
+      remoteInPath = inPath;
+    }
+
+    remotePath = remoteRoot + (remoteInPath == remoteSep ? remoteInPath : remoteSep + remoteInPath);
 
     sftpConn.mkdir(remotePath, {mode: 775}, function(err) {
       console.log('mkdir ' + remotePath, err ? 'error or dir exists' : 'ok');
@@ -180,6 +195,8 @@ module.exports = function(grunt) {
 
     localRoot = Array.isArray(this.data.src) ? this.data.src[0] : this.data.src;
     remoteRoot = Array.isArray(this.data.dest) ? this.data.dest[0] : this.data.dest;
+    remoteSep = this.data.server_sep ? this.data.server_sep : path.sep;
+
     authVals = getAuthByKey(this.data.auth.authKey);
     exclusions = this.data.exclusions || [];
 


### PR DESCRIPTION
this should fix the flat files issue in case the server_sep option is defined in the config
otherwise it will default to the local separator

there could be a better solution of detecting the online server separator, however this fixes it manually
