### PR TITLE
add support for absolute path instead of .ftppass/env variables

### DIFF
--- a/tasks/sftp-deploy.js
+++ b/tasks/sftp-deploy.js
@@ -143,25 +143,19 @@ module.exports = function(grunt) {
     });
   }
 
-  function getAuthByKey (inKey) {
-    if (process.env[inKey]) {
-      return JSON.parse(process.env[inKey]);
+  function getAuthByKey(inKey) {
+    if (inKey !== null) {
 
-    } else if (fs.existsSync(inKey)) {
-      var tmpStr = grunt.file.read(inKey);
-      var retVal = null;
-      if (inKey !== null && tmpStr.length) retVal = JSON.parse(tmpStr);
-      return retVal;
+      if (process.env[inKey]) {
+        return JSON.parse(process.env[inKey]);
 
-    } else {
-      var tmpStr;
-      var retVal = null;
+      } else if (fs.existsSync(inKey)) {
+        return JSON.parse(grunt.file.read(inKey)) || null;
 
-      if (fs.existsSync('.ftppass')) {
-        tmpStr = grunt.file.read('.ftppass');
-        if (inKey !== null && tmpStr.length) retVal = JSON.parse(tmpStr)[inKey];
+      } else if (fs.existsSync('.ftppass')) {
+        return JSON.parse(grunt.file.read('.ftppass'))[inKey] || null;
       }
-      return retVal;
+
     }
   }
 


### PR DESCRIPTION
To follow-up on my previous pull request (#47), this commit adds support for passing the absolute path to a JSON file in the `authKey` parameter instead of the _.ftppass_ config or an environment variable.

The user can seamlessly specify either of these, the grunt task will first check for an environment variable, then a path, or finally default back to _.ftppass_

**Example:**

_/home/JohnDoe/sftp/my-json-file.json_

``` json
{
    "username": "your-username",
    "keyLocation": "/path/to/your/key",
    "password": "your-strong-password"
}
```

_Gruntfile.js_

``` javascript
"sftp-deploy": {
    build: {
       auth: {
           host: 'my-ftp.com',
           port: '5678',
           authKey: '/home/JohnDoe/sftp/my-json-file.json'
       }
      ...
    }
}
```
