### PR TITLE
getAuthByKey: added option to use object definition instead of string only

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ export GRUNT_SFTP="{
 
 Then you simply pass the variable name as the `sftp-deploy` tasks's `authKey` parameter inside your `Gruntfile.js`
 
+If you are fetching credentials from different sources like internal grunt config objects or shell prompt there is another option. You can pass the object with key:value pairs like they are stored in `.ftppass` as `authKey` parameter.
 
 ## Dependencies
 

--- a/tasks/sftp-deploy.js
+++ b/tasks/sftp-deploy.js
@@ -146,7 +146,10 @@ module.exports = function(grunt) {
   function getAuthByKey(inKey) {
     if (inKey !== null) {
 
-      if (process.env[inKey]) {
+      if (typeof inKey == 'object') {
+        return inKey;
+
+      } else if (process.env[inKey]) {
         return JSON.parse(process.env[inKey]);
 
       } else if (fs.existsSync(inKey)) {


### PR DESCRIPTION
Using grunt-prompt or other sources to input passphrase. Therefore we need to work with grunt-config based auth objects, too.
