### PR TITLE
on windows machine remote sep, when no enforced, is \

### DIFF
--- a/tasks/sftp-deploy.js
+++ b/tasks/sftp-deploy.js
@@ -230,7 +230,7 @@ module.exports = function(grunt) {
     transferred = 0;
     localRoot = Array.isArray(this.data.src) ? this.data.src[0] : this.data.src;
     remoteRoot = Array.isArray(this.data.dest) ? this.data.dest[0] : this.data.dest;
-    remoteSep = this.data.serverSep ? this.data.serverSep : path.sep;
+    remoteSep = this.data.serverSep ? this.data.serverSep : "/";
     var concurrency = parseInt(this.data.concurrency) || 4;
     with_progress = this.data.progress || !grunt.option("verbose");
 
@@ -312,7 +312,6 @@ module.exports = function(grunt) {
         });
         sftp.on('close', function (e) {
           grunt.verbose.writeln('SFTP :: close',e);
-          done_handler();
         });
         sftp.on('error', function (e) {
           grunt.fail.fatal('SFTP :: error', e);


### PR DESCRIPTION
This is not compatible with a linux ssh subsystem
thus by default it is naturally preferable to set it to '/' when not explicitly defined in the configuration