### PR TITLE
fix missing line breaks after each file trasnfer when verbose is ON

### DIFF
--- a/tasks/sftp-deploy.js
+++ b/tasks/sftp-deploy.js
@@ -86,17 +86,17 @@ module.exports = function(grunt) {
     fromFile = localRoot + path.sep + inFilename;
     toFile = remoteRoot + remoteSep + inFilename;
 
-    grunt.verbose.writeln(fromFile + ' to ' + toFile);
+    grunt.verbose.write(fromFile + ' to ' + toFile);
 
     var f_size = fs.statSync(fromFile).size;
 
     var upload = function(fromFile, toFile, cb) {
       sftpConn.fastPut( fromFile, toFile, function(err){
         if (err){
-          log.write((' Error uploading file: ' + err.message).red + '\n');
+          log.writeln((' Error uploading file: ' + err.message).red );
           cb(err);
         } else {
-          grunt.verbose.write(' done'.green + '\n' );
+          grunt.verbose.writeln(' done'.green );
           if( with_progress ) progressLogger.tick();
           transferred += parseInt(f_size/1024);
           cb(null);


### PR DESCRIPTION
fix missing line breaks after each file trasnfer when verbose is ON
