### PR TITLE
ensure done_handler is called once

### DIFF
--- a/tasks/sftp-deploy.js
+++ b/tasks/sftp-deploy.js
@@ -269,7 +269,10 @@ module.exports = function(grunt) {
     }
 
     var has_transferred_all_files = false;
+    var already_done = false;
     var done_handler = function(err){
+      if( already_done ) return;
+      already_done = true;
       sshConn.end();
       if (cacheEnabled) {
         fs.writeFileSync(cacheFileName, JSON.stringify(cache) || {});
@@ -290,12 +293,15 @@ module.exports = function(grunt) {
     });
     sshConn.on('error', function (e) {
       grunt.fail.fatal('Connection :: error', e);
+      done_handler();
     });
     sshConn.on('end', function (e) {
       grunt.verbose.writeln('Connection :: end', e);
+      done_handler();
     });
     sshConn.on('close', function (e) {
       grunt.verbose.writeln('Connection :: close', e);
+      done_handler();
     });
 
     sshConn.on('ready', function () {
@@ -308,7 +314,7 @@ module.exports = function(grunt) {
 
         sftp.on('end', function (e) {
           grunt.verbose.writeln('SFTP :: SFTP session closed',e);
-          // console.trace();
+          done_handler();
         });
         sftp.on('close', function (e) {
           grunt.verbose.writeln('SFTP :: close',e);
@@ -316,6 +322,7 @@ module.exports = function(grunt) {
         });
         sftp.on('error', function (e) {
           grunt.fail.fatal('SFTP :: error', e);
+          done_handler();
         });
         sftp.on('open', function () {
           grunt.verbose.writeln('SFTP :: open');


### PR DESCRIPTION
when executed sequentially within the same nodejs process, it happens done_handler may be called twice.
Thus the second call fails because its connection get closed by the previous process.

This patch fix this issue, it also ensure done_handler is called in more possible failure case to avoid a pending process after a failure.
