### PR TITLE
remote server path bug fixed

### DIFF
--- a/tasks/sftp-deploy.js
+++ b/tasks/sftp-deploy.js
@@ -86,6 +86,10 @@ module.exports = function(grunt) {
     fromFile = localRoot + path.sep + inFilename;
     toFile = remoteRoot + remoteSep + inFilename;
 
+    if(path.sep != remoteSep) {
+      toFile = toFile.replace(new RegExp(path.sep == '\\' ? '\\\\' : '\\/', 'g'), remoteSep);
+    }
+
     grunt.verbose.write(fromFile + ' to ' + toFile);
 
     var f_size = fs.statSync(fromFile).size;


### PR DESCRIPTION
well, below is my folder structure:

js/
   -foo/bar.js

but when i deploied (from windows) to the server the folder structure is below:

js/
   -foo/
   -foo\bar.js

I have review the code and think the 'toFile' variable in [sftpPut()](https://github.com/thrashr888/grunt-sftp-deploy/blob/master/tasks/sftp-deploy.js#L87) should replace sep from local to remote, so i tried this and it work well. 

Maybe you should consider that!