### PR TITLE
Better error message if no .ftppass exists

### DIFF
--- a/tasks/sftp-deploy.js
+++ b/tasks/sftp-deploy.js
@@ -163,7 +163,7 @@ module.exports = function(grunt) {
         return JSON.parse(grunt.file.read('.ftppass'))[inKey] || null;
       }
 
-    }
+    } else return null;
   }
 
   function getKeyLocation(customKey) {
@@ -258,7 +258,7 @@ module.exports = function(grunt) {
     };
 
     // Use either password or key-based login
-    if (authVals === null) {
+    if (typeof authVals === 'undefined' || authVals === null) {
       grunt.warn('.ftppass seems to be missing or incomplete');
     } else {
       connection.username = authVals.username;


### PR DESCRIPTION
If there's no .ftppass the error message is:

```
Warning: Cannot read property 'username' of undefined Use --force to continue.
```

With these changes it reads:

```
Warning: .ftppass seems to be missing or incomplete Use --force to continue.
```
